### PR TITLE
[update] use $D4RL_DATASET_DIR if it is defined

### DIFF
--- a/d4rl_atari/offline_env.py
+++ b/d4rl_atari/offline_env.py
@@ -7,7 +7,7 @@ from os.path import expanduser
 from subprocess import Popen
 
 URI = 'gs://atari-replay-datasets/dqn/{}/{}/replay_logs/'
-BASE_DIR = os.path.join(expanduser('~'), '.d4rl', 'datasets')
+BASE_DIR = os.environ.get('D4RL_DATASET_DIR', os.path.join(expanduser('~'), '.d4rl', 'datasets'))
 
 
 def get_dir_path(env, index, epoch, base_dir=BASE_DIR):


### PR DESCRIPTION
Hi, Just a minor change to use the $D4RL_DATASET_DIR environment variable instead of ~/.d4rl/datasets/, if it is defined. This is useful for me as I don't have much space in my home directory. I hope you find this change is sensible.
